### PR TITLE
Enable original catalog items when exiting story

### DIFF
--- a/lib/Models/Receipt.js
+++ b/lib/Models/Receipt.js
@@ -42,7 +42,7 @@ function exitStory(terria, viewState) {
   });
 
   // Reset camera
-  terria.currentViewer.zoomTo(terria.homeView, 0.0);
+  terria.currentViewer.zoomTo(terria.homeView, 1.5);
 }
 
 function getHotspotsCatalogItems(terria) {

--- a/lib/Models/Receipt.js
+++ b/lib/Models/Receipt.js
@@ -25,8 +25,9 @@ function launchStory(storyId, terria) {
 }
 
 function exitStory(terria, viewState) {
-  // Hide story
+  // Hide & reset story
   viewState.storyShown = false;
+  viewState.currentStoryId = 0;
   terria.currentViewer.notifyRepaintRequired();
 
   // Enable original catalog items

--- a/lib/Models/Receipt.js
+++ b/lib/Models/Receipt.js
@@ -30,9 +30,13 @@ function exitStory(terria, viewState) {
   terria.currentViewer.notifyRepaintRequired();
 
   // Enable original catalog items
-  getHotspotsCatalogItems(terria).forEach(item => {
-    item.isEnabled = true;
-    item.isShown = true;
+  const hotspotItems = getHotspotsCatalogItems(terria);
+  terria.nowViewing.items.forEach(item => {
+    const doShow =
+      item.name === "EU Lines!- Mapbox Style" ||
+      hotspotItems.indexOf(item) >= 0;
+    item.isEnabled = doShow;
+    item.isShown = doShow;
   });
 
   // Reset camera

--- a/lib/Models/Receipt.js
+++ b/lib/Models/Receipt.js
@@ -28,6 +28,7 @@ function exitStory(terria, viewState) {
   // Hide & reset story
   viewState.storyShown = false;
   viewState.currentStoryId = 0;
+  terria.showSplitter = false;
   terria.currentViewer.notifyRepaintRequired();
 
   // Enable original catalog items

--- a/lib/Models/Receipt.js
+++ b/lib/Models/Receipt.js
@@ -1,4 +1,3 @@
-
 /**
  * Open Story from the popup
  * @param features
@@ -26,8 +25,21 @@ function launchStory(storyId, terria) {
 }
 
 function exitStory(terria, viewState) {
+  // Hide story
   viewState.storyShown = false;
   terria.currentViewer.notifyRepaintRequired();
+
+  // Enable original catalog items
+  terria.nowViewing.items.forEach(item => {
+    const doShow =
+      item.name === "EU Lines!- Mapbox Style" ||
+      item.name === "Hotspots overview";
+    item.isEnabled = doShow;
+    item.isShown = doShow;
+  });
+
+  // Reset camera
+  terria.currentViewer.zoomTo(terria.homeView, 0.0);
 }
 
 module.exports = {

--- a/lib/Models/Receipt.js
+++ b/lib/Models/Receipt.js
@@ -30,16 +30,20 @@ function exitStory(terria, viewState) {
   terria.currentViewer.notifyRepaintRequired();
 
   // Enable original catalog items
-  terria.nowViewing.items.forEach(item => {
-    const doShow =
-      item.name === "EU Lines!- Mapbox Style" ||
-      item.name === "Hotspots overview";
-    item.isEnabled = doShow;
-    item.isShown = doShow;
+  getHotspotsCatalogItems(terria).forEach(item => {
+    item.isEnabled = true;
+    item.isShown = true;
   });
 
   // Reset camera
   terria.currentViewer.zoomTo(terria.homeView, 0.0);
+}
+
+function getHotspotsCatalogItems(terria) {
+  const hotspotsCatalogGroup = terria.catalog.group.items.find(item => {
+    return item.name === "Hotspot Overview";
+  });
+  return hotspotsCatalogGroup.items;
 }
 
 module.exports = {

--- a/lib/ReactViews/Story/RCStoryPanel.jsx
+++ b/lib/ReactViews/Story/RCStoryPanel.jsx
@@ -11,6 +11,7 @@ import when from "terriajs-cesium/Source/ThirdParty/when";
 import defined from "terriajs-cesium/Source/Core/defined";
 import Styles from "./story-panel.scss";
 import { withTranslation } from "react-i18next";
+import { exitStory as rcExitStory } from "../../Models/Receipt";
 
 export function activateStory(story, terria) {
   if (story.shareData) {
@@ -148,8 +149,7 @@ const RCStoryPanel = createReactClass({
   },
 
   exitStory() {
-    this.props.viewState.storyShown = false;
-    this.props.terria.currentViewer.notifyRepaintRequired();
+    rcExitStory(this.props.terria, this.props.viewState);
   },
 
   render() {


### PR DESCRIPTION
[AB#277](https://dev.azure.com/nlesc-team-cat/9cb0bc0a-da81-42e9-b2bf-7ada019f9189/_workitems/edit/277) Shows the original catalog items when exiting a story and hides the one from the story.