### PR TITLE
Use sector id for storage

### DIFF
--- a/lib/ReactViews/RCBuilder/RCStoryEditor/RCSectorSelection/RCSectorSelection.jsx
+++ b/lib/ReactViews/RCBuilder/RCStoryEditor/RCSectorSelection/RCSectorSelection.jsx
@@ -26,17 +26,13 @@ const RCSectorSelection = props => {
                 <label>
                   <input
                     type="checkbox"
-                    value={sector.title}
+                    value={sector.id}
+                    checked={selectedSectors.includes(sector.id)}
                     onChange={onSectorSelected}
                   />
                   <Icon
                     glyph={
-                      selectedSectors.includes(
-                        sector.title
-                          .split(" ")
-                          .join("_")
-                          .toUpperCase()
-                      )
+                      selectedSectors.includes(sector.id)
                         ? sector.iconHover
                         : sector.icon
                     }

--- a/lib/ReactViews/RCBuilder/RCStoryEditor/RCStoryEditor.jsx
+++ b/lib/ReactViews/RCBuilder/RCStoryEditor/RCStoryEditor.jsx
@@ -87,10 +87,7 @@ function RCStoryEditor(props) {
     setShortDescription(event.target.value);
   };
   const onSectorChanged = event => {
-    const sector = event.target.value
-      .split(" ")
-      .join("_")
-      .toUpperCase();
+    const sector = event.target.value;
     // check if the check box is checked or unchecked
     if (event.target.checked) {
       // add the  value of the checkbox to selectedSectors array


### PR DESCRIPTION
instead of converting to enum name

### What this PR does

Fixes RECEIPT-H2020/TerriaMap#85

This fixes the storage of the sector ids, which was previously done by converting the sector name to the enum entry of that sector. As the graphql schema doesn't use the enum anymore, we pass the sector id directly, which is a string.

### Checklist

-   [ ] There are unit tests to verify my changes are correct or unit tests aren't applicable (if so, write quick reason why unit tests don't exist)
-   [ ] I've updated CHANGES.md with what I changed.
