### PR TITLE
Add Welcome/Info icon to sector icons for welcome page

### DIFF
--- a/lib/ReactViews/Icon.jsx
+++ b/lib/ReactViews/Icon.jsx
@@ -95,6 +95,9 @@ const GLYPHS = {
   coastalInfrastructureHover: require("../../wwwroot/images/icons/receipt/sector-icons/coastal_infrastructure_hover.svg"),
   financeHover: require("../../wwwroot/images/icons/receipt/sector-icons/finance_hover.svg"),
 
+  about: require("../../wwwroot/images/icons/receipt/sector-icons/about.svg"),
+  aboutHover: require("../../wwwroot/images/icons/receipt/sector-icons/about_hover.svg"),
+
   info: require("../../wwwroot/images/icons/receipt/info.svg"),
   back: require("../../wwwroot/images/icons/receipt/backTo.svg"),
   roundedPlay: require("../../wwwroot/images/icons/receipt/rounded-play.svg"),

--- a/lib/ReactViews/RCSectorPanel/SidePanelSectorTabs.jsx
+++ b/lib/ReactViews/RCSectorPanel/SidePanelSectorTabs.jsx
@@ -51,6 +51,16 @@ class SidePanelSectorTabs extends React.Component {
               </div>
             </div>
             <div className={Styles.tabsContainer}>
+              <div key={`welcome`}>
+                <Tooltip content="About" direction="bottom" delay="100">
+                  <Link to="/">
+                    <Icon
+                      glyph={selectedSectorId === -1 ? Icon.GLYPHS['aboutHover'] : Icon.GLYPHS['about']}
+                      className={selectedSectorId === -1 ? Styles.selectedTab : ""}
+                    />
+                  </Link>
+                </Tooltip>
+              </div>
               {sectors.map((sector, id) => {
                 return (
                   <div key={`sidePanelSectorTabs/sector/${sector.id}`}>

--- a/wwwroot/images/icons/receipt/sector-icons/about.svg
+++ b/wwwroot/images/icons/receipt/sector-icons/about.svg
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="62"
+   height="62"
+   viewBox="0 0 62 62"
+   fill="none"
+   version="1.1"
+   id="svg27"
+   sodipodi:docname="about.svg"
+   inkscape:version="1.2 (dc2aedaf03, 2022-05-15)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs31" />
+  <sodipodi:namedview
+     id="namedview29"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="13"
+     inkscape:cx="33.192308"
+     inkscape:cy="31.692308"
+     inkscape:window-width="1920"
+     inkscape:window-height="1009"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1" />
+  <path
+     fill-rule="evenodd"
+     clip-rule="evenodd"
+     d="m 60.4183,31.2394 c 0,16.1487 -13.0908,29.2394 -29.2394,29.2394 C 15.0308,60.4788 1.93945,47.3881 1.93945,31.2394 1.93945,15.0908 15.0308,2 31.1789,2 47.3275,2 60.4183,15.0908 60.4183,31.2394 Z"
+     stroke="#0c70a8"
+     stroke-width="2.21305"
+     id="path21"
+     style="display:inline"
+     inkscape:label="path21" />
+  <g
+     inkscape:groupmode="layer"
+     id="layer1"
+     inkscape:label="i">
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:53.3333px;font-family:Perpetua;-inkscape-font-specification:'Perpetua, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#0c70a8;fill-opacity:1"
+       x="23.392422"
+       y="47.932098"
+       id="text250"
+       inkscape:label="text250"><tspan
+         sodipodi:role="line"
+         id="tspan248"
+         x="23.392422"
+         y="47.932098">i</tspan></text>
+  </g>
+</svg>

--- a/wwwroot/images/icons/receipt/sector-icons/about_hover.svg
+++ b/wwwroot/images/icons/receipt/sector-icons/about_hover.svg
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="62"
+   height="62"
+   viewBox="0 0 62 62"
+   fill="none"
+   version="1.1"
+   id="svg27"
+   sodipodi:docname="about_hover.svg"
+   inkscape:version="1.2 (dc2aedaf03, 2022-05-15)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs31" />
+  <sodipodi:namedview
+     id="namedview29"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="13"
+     inkscape:cx="33.192308"
+     inkscape:cy="31.692308"
+     inkscape:window-width="1920"
+     inkscape:window-height="1009"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg27" />
+  <path
+     fill-rule="evenodd"
+     clip-rule="evenodd"
+     d="m 60.4183,31.2394 c 0,16.1487 -13.0908,29.2394 -29.2394,29.2394 C 15.0308,60.4788 1.93945,47.3881 1.93945,31.2394 1.93945,15.0908 15.0308,2 31.1789,2 47.3275,2 60.4183,15.0908 60.4183,31.2394 Z"
+     stroke="#0c70a8"
+     stroke-width="2.21305"
+     id="path21"
+     style="display:inline;fill:#0c70a8;fill-opacity:1"
+     inkscape:label="path21" />
+  <g
+     inkscape:groupmode="layer"
+     id="layer1"
+     inkscape:label="i">
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:53.3333px;font-family:Perpetua;-inkscape-font-specification:'Perpetua, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#ffffff;fill-opacity:1"
+       x="23.392422"
+       y="47.932098"
+       id="text250"
+       inkscape:label="text250"><tspan
+         sodipodi:role="line"
+         id="tspan248"
+         x="23.392422"
+         y="47.932098">i</tspan></text>
+  </g>
+</svg>


### PR DESCRIPTION
I've reused one of the existing icons and replaced the sector logo with an **i** from the `Perpetua` font (included in InkScape).

- Is this clear enough?
- Do I have to check for licensing of this font? (or find a royalty-free one that looks similar)

Selected:
![welcome_page](https://user-images.githubusercontent.com/8833517/214042236-28c9a651-62d5-4272-aa89-0665d6a944ca.png)

Deselected
![welcome_page_deselected](https://user-images.githubusercontent.com/8833517/214042242-c6467ed6-6e8f-4169-bd5e-764cf061de6c.png)
